### PR TITLE
Bump spark-core_2.12 from 3.1.2 to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <scala.version>2.12</scala.version>
-    <spark.version>3.1.2</spark.version>
+    <spark.version>3.4.0</spark.version>
     <junit.version>4.13.1</junit.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
   </properties>


### PR DESCRIPTION
Bumps spark-core_2.12 from 3.1.2 to 3.4.0.

---
updated-dependencies:
- dependency-name: org.apache.spark:spark-core_2.12 dependency-type: direct:production ...